### PR TITLE
Fix how to build binaries

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,8 +23,8 @@ fmt: setup
 	goimports -w .
 
 build:
-	vgo build -o bin/$(NAME) cmd/nolmandy/main.go
-	vgo build -o bin/$(NAME)-server cmd/nolmandy-server/main.go
+	cd cmd/nolmandy; vgo build -o ../../bin/$(NAME)
+	cd cmd/nolmandy-server; vgo build -o ../../bin/$(NAME)-server
 
 clean:
 	rm bin/$(NAME)


### PR DESCRIPTION
With go 1.10.3 and vgo devel +1b870077c8, this error occurs:
build main: cannot find module for path main

Ref https://github.com/golang/go/issues/26798